### PR TITLE
Modify findMountPoint() to parse hdiutil info in plist format 

### DIFF
--- a/lib/updater.js
+++ b/lib/updater.js
@@ -121,18 +121,30 @@ Updater.prototype = {
     },
     
     findMountPoint: function(dmg_name, callback) {
-        exec('hdiutil info', function(err, stdout){
+       var plist = require('plist-with-patches');
+        exec('hdiutil info -plist', function(err, stdout) {
             if (err) throw err;
+
+            var results = plist.parseStringSync(stdout);
+            var images = results.images;
             
-            var results = stdout.split("\n");
-            
-            for (var i=0,l=results.length;i<l;i++) {
-                if (results[i].match(dmg_name)) {
-                    callback(results[i].split("\t").pop());
+            if(images) {
+                for (var i=0,l=images.length;i<l;i++) {
+               
+                var ents = images[i]['system-entities'];
+
+                var mp = _.find(ents, function(ent) {
+                    if(_.has(ent, 'mount-point') && ent['mount-point'].match(dmg_name)) {
+                        return ent['mount-point'];
+                    }
+                });
+                console.log('Mount Point Found');
+                if(mp) {
+                    callback(mp['mount-point']);
                     return;
+                }               
                 }
             }
-            
             throw "Mount point not found";
         });
     },

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "url": "git://github.com/sqwiggle/node-webkit-mac-updater.git"
   },
   "dependencies": {
-    "underscore": "*"
+    "underscore": "*",
+     "plist-with-patches": "^0.5.1"
   },
   "devDependencies": {
     "mocha": ">= 1.17.1",


### PR DESCRIPTION
Avoids having to parse entire output of hdiutil info as a string and allows targeting and parsing only the 'System Entities' portion of the output where mounted volumes are listed.
